### PR TITLE
Updated bands from 3GPP TS 36.101 v16.6.0

### DIFF
--- a/data/fb.csv
+++ b/data/fb.csv
@@ -1,15 +1,15 @@
 operating_band,uplink_lower,uplink_upper,downlink_lower,downlink_upper,duplex_mode,note
-1,1920,1980,2110,2170,FDD,
+1,1920,1980,2110,2170,FDD,A UE that complies with the E-UTRA Band 65 minimum requirements in this specification shall also comply with the E-UTRA Band 1 minimum requirements.
 2,1850,1910,1930,1990,FDD,
 3,1710,1785,1805,1880,FDD,
 4,1710,1755,2110,2155,FDD,
 5,824,849,869,894,FDD,
-6,830,840,875,885,FDD,Band 6 is not applicable
+6,830,840,875,885,FDD,Band 6 is not applicable.
 7,2500,2570,2620,2690,FDD,
 8,880,915,925,960,FDD,
 9,1749.9,1784.9,1844.9,1879.9,FDD,
 10,1710,1770,2110,2170,FDD,
-11,1427.9,1447.9,1475.9,1495.9,FDD,
+11,1427.9,1447.9,1475.9,1495.9,FDD,A UE that complies with the E-UTRA Band 74 minimum requirements in this specification shall also comply with the E-UTRA Band 11 and Band 21 minimum requirements.
 12,699,716,729,746,FDD,
 13,777,787,746,756,FDD,
 14,788,798,758,768,FDD,
@@ -18,19 +18,19 @@ operating_band,uplink_lower,uplink_upper,downlink_lower,downlink_upper,duplex_mo
 17,704,716,734,746,FDD,
 18,815,830,860,875,FDD,
 19,830,845,875,890,FDD,
-20,832,862,791,821,,
-21,1447.9,1462.9,1495.9,1510.9,FDD,
+20,832,862,791,821,FDD,
+21,1447.9,1462.9,1495.9,1510.9,FDD,A UE that complies with the E-UTRA Band 74 minimum requirements in this specification shall also comply with the E-UTRA Band 11 and Band 21 minimum requirements.
 22,3410,3490,3510,3590,FDD,
-23,2000,2020,2180,2200,FDD,Band 23 is not applicable
+23,2000,2020,2180,2200,FDD,Band 23 is not applicable.
 24,1626.5,1660.5,1525,1559,FDD,
 25,1850,1915,1930,1995,FDD,
 26,814,849,859,894,FDD,
 27,807,824,852,869,FDD,
 28,703,748,758,803,FDD,
-29,N/A,N/A,717,728,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell
-30,2305,2315,2350,2360,FDD,
+29,N/A,N/A,717,728,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell.
+30,2305,2315,2350,2360,FDD,Uplink transmission is not allowed at this band for UE with external vehicle-mounted antennas.
 31,452.5,457.5,462.5,467.5,FDD,
-32,N/A,N/A,1452,1496,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell
+32,N/A,N/A,1452,1496,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell.
 33,1900,1920,1900,1920,TDD,
 34,2010,2025,2010,2025,TDD,
 35,1850,1910,1850,1910,TDD,
@@ -44,14 +44,27 @@ operating_band,uplink_lower,uplink_upper,downlink_lower,downlink_upper,duplex_mo
 43,3600,3800,3600,3800,TDD,
 44,703,803,703,803,TDD,
 45,1447,1467,1447,1467,TDD,
-46,5150,5925,5150,5925,TDD,"This band is an unlicensed band restricted to licensed-assisted operation using Frame Structure Type 3. In this version of the specification, restricted to E-UTRA DL operation when carrier aggregation is configured. Band 46 is divided into four sub-bands as in Table 5.5-1A"
-46.2,5150,5250,5150,5250,TDD,
-46.3,5250,5350,5250,5350,TDD,
-46.4,5470,5725,5470,5725,TDD,
-46.5,5725,5925,5725,5925,TDD,
-65,1920,2010,2110,2200,FDD,
-66,1710,1780,2110,2200,FDD,The range 2180 – 2200 MHz of the DL operating band is restricted to E-UTRA operation when carrier aggregation is configured
-67,N/A,N/A,738,758,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell
+46,5150,5925,5150,5925,TDD,"This band is an unlicensed band restricted to licensed-assisted operation using Frame Structure Type 3. In this version of the specification, restricted to E-UTRA DL operation when carrier aggregation is configured"
+47,5855,5925,5855,5925,TDD,This band is unlicensed band used for V2X communication. There is no expected network deployment in this band so Frame Structure Type 1 is used.
+48,3550,3700,3550,3700,TDD,
+49,3550,3700,3550,3700,TDD,This band is restricted to licensed-assisted operation using Frame Structure Type 3.
+50,1432,1517,1432,1517,TDD,UE that complies with the E-UTRA Band 50 minimum requirements in this specification shall also comply with the E-UTRA Band 51 minimum requirements.
+51,1427,1432,1427,1432,TDD,UE that complies with the E-UTRA Band 50 minimum requirements in this specification shall also comply with the E-UTRA Band 51 minimum requirements.
+52,3300,3400,3300,3400,TDD,
+53,2483.5,2495,2483.5,2495,TDD,
+64,Reserved,Reserved,Reserved,Reserved,,
+65,1920,2010,2110,2200,FDD,A UE that complies with the E-UTRA Band 65 minimum requirements in this specification shall also comply with the E-UTRA Band 1 minimum requirements.
+66,1710,1780,2110,2200,FDD,"The range 2180-2200 MHz of the DL operating band is restricted to E-UTRA operation when carrier aggregation is configured. A UE that supports E-UTRA Band 66 shall receive in the entire DL operating band. A UE that supports E-UTRA Band 66 and CA operation in any CA band shall also comply with the minimum requirements specified for the DL CA configurations CA_66B, CA_66C and CA_66A-66A. A UE that complies with the E-UTRA Band 66 minimum requirements in this specification shall also comply with the E-UTRA Band 4 minimum requirements."
+67,N/A,N/A,738,758,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell.
 68,698,728,753,783,FDD,
 69,N/A,N/A,2570,2620,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell.
-70,1695,1710,1995,2020,FDD,The range 2010-2020 MHz of the DL operating band is restricted to E-UTRA operation when carrier aggregation is configured and TX-RX separation is 300 MHz.  The range 2005-2020 MHz of the DL operating band is restricted to E-UTRA operation when carrier aggregation is configured and TX-RX separation is 295 MHz
+70,1695,1710,1995,2020,FDD,The range 2010-2020 MHz of the DL operating band is restricted to E-UTRA operation when carrier aggregation is configured and TX-RX separation is 300 MHz The range 2005-2020 MHz of the DL operating band is restricted to E-UTRA operation when carrier aggregation is configured and TX-RX separation is 295 MHz.
+71,663,698,617,652,FDD,
+72,451,456,461,466,FDD,
+73,450,455,460,465,FDD,
+74,1427,1470,1475,1518,FDD,A UE that complies with the E-UTRA Band 74 minimum requirements in this specification shall also comply with the E-UTRA Band 11 and Band 21 minimum requirements.
+75,N/A,N/A,1432,1517,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell. A UE that complies with the E-UTRA Band 75 minimum requirements in this specification shall also comply with the E-UTRA Band 76 minimum requirements.
+76,N/A,N/A,1427,1432,FDD,Restricted to E-UTRA operation when carrier aggregation is configured. The downlink operating band is paired with the uplink operating band (external) of the carrier aggregation configuration that is supporting the configured Pcell. A UE that complies with the E-UTRA Band 75 minimum requirements in this specification shall also comply with the E-UTRA Band 76 minimum requirements.
+85,698,716,728,746,FDD,
+87,410,415,420,425,FDD,
+88,412,417,422,427,FDD,


### PR DESCRIPTION
Updated E-UTRA operating bands from Table 5.5-1 in 3GPP Technical Specification TS 36.101 v16.6.0 (2020-06).